### PR TITLE
Removed bug in code for copy-pasting

### DIFF
--- a/installation/docker-guide.md
+++ b/installation/docker-guide.md
@@ -20,10 +20,10 @@ services:
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:5.5.2
     environment:
-    	- http.host=0.0.0.0
-    	- transport.host=0.0.0.0
-    	- xpack.security.enabled=false
-    	- cluster.name=hive
+      - http.host=0.0.0.0
+      - transport.host=0.0.0.0
+      - xpack.security.enabled=false
+      - cluster.name=hive
       - script.inline=true
       - thread_pool.index.queue_size=100000
       - thread_pool.search.queue_size=100000


### PR DESCRIPTION
Copy-pasting the old code leads to an error during YAML parsing. By using the same padding, it works. Probably just inconvenient for people that know about it, but may have thrown some beginners off.