### PR TITLE
Update curly brackets on default-configuration.md

### DIFF
--- a/admin/default-configuration.md
+++ b/admin/default-configuration.md
@@ -169,6 +169,7 @@ cortex {
   #    }
   #  }
   #}
+}
 
 # MISP configuration
 ########


### PR DESCRIPTION
Added missing closing curly bracket which would cause default config file to fail on loading.