### PR TITLE
Important notes about "--no-config" argument

### DIFF
--- a/admin/configuration.md
+++ b/admin/configuration.md
@@ -4,6 +4,12 @@ The configuration file of TheHive is `/etc/thehive/application.conf` by default.
 
 You can have a look at the [default settings](default-configuration.md).
 
+Important note:
+To take effect, be sure that:
+- "/path/to/application.conf" is readable for the user who runs the docker daemon,
+- you specified `command: --no-config` in your `docker-compose.yml` file
+
+
 ### 1. Database
 
 TheHive uses the Elasticsearch search engine to store all persistent data. Elasticsearch is not part of TheHive package. It must be installed and configured as a standalone instance which can be located on the same machine. For more information on how to set up Elasticsearch, please refer to [Elasticsearch installation guide](https://www.elastic.co/guide/en/elasticsearch/reference/5.6/setup.html).

--- a/installation/install-guide.md
+++ b/installation/install-guide.md
@@ -121,6 +121,10 @@ volumes:
     - /path/to/application.conf:/etc/thehive/application.conf
 ```
 
+To take effect, be sure that:
+- '/path/to/application.conf' is readable for the user who runs the docker daemon (typically 644)
+- you specified `command: --no-config` in your `docker-compose.yml` file
+
 You should define where the data (i.e. the Elasticsearch database) will be located on your operating system by adding the following lines in the `elasticsearch` section of your docker-compose file:
 ```
 volumes:


### PR DESCRIPTION
This argument must be present when a detailed configuration file is used.

