### PR TITLE
Fix missing "}" in default configuration

### DIFF
--- a/admin/default-configuration.md
+++ b/admin/default-configuration.md
@@ -169,6 +169,7 @@ cortex {
   #    }
   #  }
   #}
+}
 
 # MISP configuration
 ########


### PR DESCRIPTION
Cortex configuration curly brace was not closed.