### PR TITLE
Unset HTTP Connection header in sample nginx conf

### DIFF
--- a/admin/configuration.md
+++ b/admin/configuration.md
@@ -621,6 +621,7 @@ You can choose any reverse proxy to add SSL on TheHive. Below an example of NGIN
 					add_header				Strict-Transport-Security "max-age=31536000; includeSubDomains";
 					proxy_pass              http://127.0.0.1:9000/;
 					proxy_http_version      1.1;
+					proxy_set_header Connection ""; # cf. https://github.com/akka/akka/issues/19542
 			}
 	}
 ```


### PR DESCRIPTION
As described in https://github.com/akka/akka/issues/19542, Akka seems to have a hard time handling HTTP requests made with `Connection: close` and closes the connection too fast, causing browsers to fail with ERR_CONTENT_LENGTH_MISMATCH errors. The easiest fix is to remove this header at the reverse proxy level.

I have successfully solved this issue on my side thanks to this modification.