### PR TITLE
Update install-guide.md

### DIFF
--- a/installation/install-guide.md
+++ b/installation/install-guide.md
@@ -231,7 +231,7 @@ If you'd rather start the application as a service, use the following commands:
 ```bash
 sudo addgroup thehive
 sudo adduser --system thehive
-sudo cp /opt/thehive/package/thehive.service /usr/lib/systemd/system
+sudo cp /opt/thehive/package/thehive.service /usr/lib/systemd/system/
 sudo chown -R thehive:thehive /opt/thehive
 sudo chgrp thehive /etc/thehive/application.conf
 sudo chmod 640 /etc/thehive/application.conf


### PR DESCRIPTION
Without the trailing slash the command obliterates the existing /var/lib/systemd/system directory.