### PR TITLE
Documentation for OAuth2/OpenID Connect authentication

### DIFF
--- a/admin/configuration.md
+++ b/admin/configuration.md
@@ -305,12 +305,37 @@ In addition, you need to configure your token endpoint (`auth.oauth2.tokenUrl`) 
 ```
 
 #### 3.2.1. Roles mappings
-You can choose a roles mappings with the `auth.sso.mapper` parameter. The available options are `simple` and `group`:
+You can choose a roles mapping with the `auth.sso.mapper` parameter. The available options are `simple` and `group`:
 
 - Using simple mapping, we assume that the user info retreived from `auth.oauth2.userUrl` contains the roles associated to the OAuth2 user. They can be: `read`, `write` or `admin`.
 - Using groups mappings, we assume the retreived user info contains groups that have to be associated to internal roles. In that case, you have to define mapppings in `auth.sso.groups.mappings`. If a user has multiple groups, mapped roles are merged. If you need to retreive groups from another endpoint that the one used for user info, you can provide it in `auth.sso.groups.url`.
 
-Finally, you can setup default roles associated with user with no roles/groups retreived, using the `auth.sso.defaultRoles`.
+The retrieved groups can be a valid JSON array or a string listing them:
+```
+{
+  "sub":    "userid1",
+  "name":   "User name 1",
+  "groups": ["admin-profile-name", "reader-profile-name"]
+}
+
+OR
+
+{
+  "sub":    "userid2",
+  "name":   "User name 2",
+  "groups": "[admin-profile-name, reader-profile-name, \"another profile\", 'a last group']"
+}
+
+OR
+
+{
+  "sub":    "userid3",
+  "name":   "User name 3",
+  "groups": "the-only-group-of-the-user"
+}
+```
+
+Finally, you can setup default roles associated with user with no roles/groups retreived, using the `auth.sso.defaultRoles` parameter.
 
 #### 3.2.2. User autocreation, autoupdate and autologin
 The main advantage of OAuth2/OpenID Connect authentication is you won't need to create an account on TheHive for each OAuth2 user if you set the config parameter `auth.sso.autocreate` to `true`. However, by default, OAuth2 users won't be updated on SSO login unless you set `auth.sso.autoupdate` to `true`. If you set this last parameter, roles and name will be fetched from retrieved user info and will be updated in local database on each login of the user.


### PR DESCRIPTION
This patch provides documentation for the OAuth2/OpenID Connect authentication feature. It is based on changes of TheHive-Project/TheHive#1112.