### PR TITLE
Add instructions for running TheHive on AWS ElasticSearch

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -109,7 +109,10 @@ HTTP can disabled by adding line `http.port=disabled`. Please read the [relevant
 This is a setting of the Play framework that is documented on its website. Please refer to [https://www.playframework.com/documentation/2.5.x/ConfiguringHttps](https://www.playframework.com/documentation/2.5.x/ConfiguringHttps).
 
 ### Can I connect TheHive to an AWS ElasticSearch service?
-AWS Elasticsearch service only supports HTTP transport protocol. It does not support the binary protocol which the Java client used by TheHive relies on to communicate with ElasticSearch. As a result, it is not possible to setup TheHive with AWS Elasticsearch service. More information is available at the following URLs:
+For TheHive versions >= 3.4.0, yes! A small amount of additional plumbing is required - see [this blog post](https://robertheaton.com/2020/01/14/how-to-set-up-the-hive-on-aws-elasticsearch/) for a guide.
+
+For TheHive versions < 3.4.0, you can't use AWS ElasticSearch. This is because AWS Elasticsearch service only supports HTTP transport protocol. It does not support the binary protocol which the Java client used by previous versions of TheHive relies on to communicate with ElasticSearch. As a result, it is not possible to setup previous versions of TheHive with AWS Elasticsearch service. More information is available at the following URLs:
+
 - [http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/aes-limits.html](https://www.elastic.co/guide/en/elasticsearch/reference/5.1/modules-network.html#_transport_and_http_protocols )
 
 > “TCP Transport	: The service supports HTTP on port 80, but does not support TCP transport”


### PR DESCRIPTION
My team at Stripe recently deployed TheHive on top of AWS ElasticSearch, and I wrote [a short blog post](https://robertheaton.com/2020/01/14/how-to-set-up-the-hive-on-aws-elasticsearch/) about what we needed to do. This PR updates the previous FAQ saying that using AWS ES wasn't possible to instead say that it is possible for versions of TheHive >=3.4.0, and link to this post.

Very happy to make changes to the blog post if you can see anything that should be updated - repo is here https://github.com/robert/robert.github.com/blob/master/_posts/2020-01-14-how-to-set-up-the-hive-on-aws-elasticsearch.md .

Thanks for a great product!