### PR TITLE
Removed ssl on; from the Reverse Proxy config example

### DIFF
--- a/admin/configuration.md
+++ b/admin/configuration.md
@@ -751,7 +751,6 @@ You can choose any reverse proxy to add SSL on TheHive. Below an example of NGIN
 			listen 443 ssl;
 			server_name thehive.example.com;
 
-			ssl on;
 			ssl_certificate			ssl/thehive_cert.pem;
 			ssl_certificate_key		ssl/thehive_key.pem;
 


### PR DESCRIPTION
`ssl on;` is deprecated in NGINX version `0.7.14` and later [Source](https://docs.nginx.com/nginx/admin-guide/security-controls/terminating-ssl-http)