### PR TITLE
fix(api/log.md): Fixed typo in curl's url

### DIFF
--- a/api/log.md
+++ b/api/log.md
@@ -59,7 +59,7 @@ It returns:
 
 If log contains an attachment, the request must be in multipart format:
 ```
-curl -XPOST -H 'Authorization: Bearer ***API*KEY***' http://127.0.0.1:9000/api/case/AVqqdpY2yQ6w1DNC8aDh/task -F '_json={"message": "Screenshot of fake site"};type=application/json' -F 'attachment=@screenshot1.png;type=image/png'
+curl -XPOST -H 'Authorization: Bearer ***API*KEY***' http://127.0.0.1:9000/api/case/task/AVqqeXc9yQ6w1DNC8aDj/log -F '_json={"message": "Screenshot of fake site"};type=application/json' -F 'attachment=@screenshot1.png;type=image/png'
 ```
 It returns:
 ```


### PR DESCRIPTION
Hi. I found a small typo. 

Screenshot of testing:
![image](https://user-images.githubusercontent.com/33694362/74736218-0ada8b00-5274-11ea-9b8d-44ad91730f01.png)
