### PR TITLE
Few inconsistencies in doc

### DIFF
--- a/TheHive4/Installation/Install_binaries.md
+++ b/TheHive4/Installation/Install_binaries.md
@@ -46,7 +46,7 @@ Download and untgz archive from http://cassandra.apache.org/download/ in the fol
 
 ### Configuration
 
-Configure Cassandra by editing `cassandra.yaml` present in your configuration folder: 
+Configure Cassandra by editing `cassandra.yaml` present in your configuration folder:
 
 ```yml
 # content from /etc/cassandra/cassandra.yaml
@@ -88,13 +88,13 @@ To add Cassandra nodes, refer the the [related administration guide](../Administ
 
 ## Choose and install attachment storage
 
-Files uploaded in TheHive (in *task logs* or in *observables*) can be stores in localsystem, in a Hadoop filesystem (recommended) or in the graph database. 
+Files uploaded in TheHive (in *task logs* or in *observables*) can be stores in localsystem, in a Hadoop filesystem (recommended) or in the graph database.
 
 For standalone production and test servers , we recommends using local filesystem. If you think about building a cluster with TheHive, use Hadoop filesystem.
 
 ### Option 1: Local filesystem
 
-**Note**: This option is perfect if you **do not** intend to build a cluster for your instance of TheHive 4. 
+**Note**: This option is perfect if you **do not** intend to build a cluster for your instance of TheHive 4.
 
 To store files on the local filesystem, start by choosing the dedicated folder:
 
@@ -102,11 +102,11 @@ To store files on the local filesystem, start by choosing the dedicated folder:
 mkdir -p /opt/thp_data/files/thehive
 ```
 
-This path will be used in the configuration of TheHive. 
+This path will be used in the configuration of TheHive.
 
 Later, after having installed TheHive, ensure the user `thehive` owns the path chosen for storing files:
 
-``` 
+```
 chown -R thehive:thehive /opt/thp_data/files/thehive
 ```
 
@@ -114,7 +114,7 @@ chown -R thehive:thehive /opt/thp_data/files/thehive
 
 If you choose Hadoop distributed filesystem, proceed to installation of the software before configuring it.
 
-#### Installation 
+#### Installation
 
 - Download hadoop distribution from https://hadoop.apache.org/releases.html and uncompress.
 
@@ -140,7 +140,7 @@ mkdir /opt/thp_data/hdfs
 chown hadoop:root -R /opt/thp_data/hdfs
 ```
 
-- Create ssh keys for `hadoop` user: 
+- Create ssh keys for `hadoop` user:
 
 ```bash
 su - hadoop
@@ -149,7 +149,7 @@ cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 chmod 0600 ~/.ssh/authorized_keys
 ```
 
-- Update `.bashrc`file for `hadoop user  in `/etc/environment`. Add following lines: 
+- Update `.bashrc`file for `hadoop user  in `/etc/environment`. Add following lines:
 
 ```
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -163,14 +163,14 @@ export YARN_HOME=$HADOOP_HOME
 ```
 
 
-**Note**: Apache has a well detailed [documentation](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SingleCluster.html) for more advanced configuration with Hadoop. 
+**Note**: Apache has a well detailed [documentation](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SingleCluster.html) for more advanced configuration with Hadoop.
 
 
 #### Configuration the Hadoop Master
 
-Configuration files are located in `etc/hadoop` (`/opt/hadoop/etc/hadoop`). They must be identical in all nodes. 
+Configuration files are located in `etc/hadoop` (`/opt/hadoop/etc/hadoop`). They must be identical in all nodes.
 
-**Notes**: 
+**Notes**:
 
 - The configuration described there is for a single node server. This node is the master node, namenode and datanode (refer to [Hadoop documentation](https://hadoop.apache.org/docs/current/) for more information). After validating this node is running successfully, refer to the [related administration guide](../Administration/Clustering.md) to add nodes;
 - Ensure you **update** the port value to something different than `9000` as it is already reserved for TheHive application service;
@@ -250,7 +250,7 @@ bin/hdfs namenode -format
 
 ---
 
-Create the `/etc/systemd/system/hadoop.service` file with the following content: 
+Create the `/etc/systemd/system/hadoop.service` file with the following content:
 
 ```
 [Unit]
@@ -300,7 +300,7 @@ WantedBy=multi-user.target
 
 
 
-#### Start the service 
+#### Start the service
 
 ```bash
 service hadoop start
@@ -369,7 +369,7 @@ cp thehive.service /etc/systemd/system/thehive.service
 
 ### Configuration
 
-Following configurations are required to start TheHive successfully: 
+Following configurations are required to start TheHive successfully:
 
 - Secret key configuration
 - Database configuration
@@ -380,7 +380,7 @@ Following configurations are required to start TheHive successfully:
 Setup a secret key in the `/etc/thehive/secret.conf` file by running the following command:
 
 ```
-cat > /etc/thehive/secret.conf << _EOF_ 
+cat > /etc/thehive/secret.conf << _EOF_
 play.http.secret.key="$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n 1)"
 _EOF_
 ```
@@ -389,7 +389,7 @@ _EOF_
 
 To use Cassandra database, TheHive configuration file (`/etc/thehive/application.conf`) has to be edited and updated with following lines:
 
-```yaml 
+```yaml
 db {
   provider: janusgraph
   janusgraph {
@@ -425,12 +425,12 @@ If you chose [Option 1: Local filesystem](#option:1_local_filesystem) to store f
 chown -R thehive:thehive /opt/thp_data/files/thehive
 ```
 
-- add following lines to TheHive configuration file (`/etc/thehive/conf/application.conf`)
+- add following lines to TheHive configuration file (`/etc/thehive/application.conf`)
 
 ```yml
 storage {
   provider = localfs
-  localfs.directory = /opt/files/thehive
+  localfs.directory = /opt/thp_data/files/thehive
 }
 ```
 

--- a/TheHive4/Installation/Install_deb.md
+++ b/TheHive4/Installation/Install_deb.md
@@ -68,19 +68,19 @@ By default, data is stored in `/var/lib/cassandra`.
 
 ### Configuration
 
-Start by changing the `cluster_name` with `thp`. Run the command `sqlsh`: 
+Start by changing the `cluster_name` with `thp`. Run the command `sqlsh`:
 
 ```bash
 UPDATE system.local SET cluster_name = 'thp' where key='local';
 ```
 
-Then run: 
+Then run:
 
 ```
 nodetool flush
 ```
 
-Configure Cassandra by editing `/etc/cassandra/cassandra.yaml` file. 
+Configure Cassandra by editing `/etc/cassandra/cassandra.yaml` file.
 
 
 ```yml
@@ -127,13 +127,13 @@ To add Cassandra nodes, refer the the [related administration guide](../Administ
 
 ## Choose and install attachment storage
 
-Files uploaded in TheHive (in *task logs* or in *observables*) can be stores in localsystem, in a Hadoop filesystem (recommended) or in the graph database. 
+Files uploaded in TheHive (in *task logs* or in *observables*) can be stores in localsystem, in a Hadoop filesystem (recommended) or in the graph database.
 
 For standalone production and test servers , we recommends using local filesystem. If you think about building a cluster with TheHive, use Hadoop filesystem.
 
 ### Option 1: Local filesystem
 
-**Note**: This option is perfect if you **do not** intend to build a cluster for your instance of TheHive 4. 
+**Note**: This option is perfect if you **do not** intend to build a cluster for your instance of TheHive 4.
 
 To store files on the local filesystem, start by choosing the dedicated folder:
 
@@ -141,11 +141,11 @@ To store files on the local filesystem, start by choosing the dedicated folder:
 mkdir -p /opt/thp_data/files/thehive
 ```
 
-This path will be used in the configuration of TheHive. 
+This path will be used in the configuration of TheHive.
 
 Later, after having installed TheHive, ensure the user `thehive` owns the path chosen for storing files:
 
-``` 
+```
 chown -R thehive:thehive /opt/thp_data/files/thehive
 ```
 
@@ -153,7 +153,7 @@ chown -R thehive:thehive /opt/thp_data/files/thehive
 
 If you choose Hadoop distributed filesystem, proceed to installation of the software before configuring it.
 
-#### Installation 
+#### Installation
 
 - Download hadoop distribution from https://hadoop.apache.org/releases.html and uncompress.
 
@@ -179,7 +179,7 @@ mkdir /opt/thp_data/hdfs
 chown hadoop:root -R /opt/thp_data/hdfs
 ```
 
-- Create ssh keys for `hadoop` user: 
+- Create ssh keys for `hadoop` user:
 
 ```bash
 su - hadoop
@@ -188,7 +188,7 @@ cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 chmod 0600 ~/.ssh/authorized_keys
 ```
 
-- Update `.bashrc`file for `hadoop user  in `/etc/environment`. Add following lines: 
+- Update `.bashrc`file for `hadoop user  in `/etc/environment`. Add following lines:
 
 ```
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -202,14 +202,14 @@ export YARN_HOME=$HADOOP_HOME
 ```
 
 
-**Note**: Apache has a well detailed [documentation](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SingleCluster.html) for more advanced configuration with Hadoop. 
+**Note**: Apache has a well detailed [documentation](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SingleCluster.html) for more advanced configuration with Hadoop.
 
 
 #### Configuration the Hadoop Master
 
-Configuration files are located in `etc/hadoop` (`/opt/hadoop/etc/hadoop`). They must be identical in all nodes. 
+Configuration files are located in `etc/hadoop` (`/opt/hadoop/etc/hadoop`). They must be identical in all nodes.
 
-**Notes**: 
+**Notes**:
 
 - The configuration described there is for a single node server. This node is the master node, namenode and datanode (refer to [Hadoop documentation](https://hadoop.apache.org/docs/current/) for more information). After validating this node is running successfully, refer to the [related administration guide](../Administration/Clustering.md) to add nodes;
 - Ensure you **update** the port value to something different than `9000` as it is already reserved for TheHive application service;
@@ -289,7 +289,7 @@ bin/hdfs namenode -format
 
 ---
 
-Create the `/etc/systemd/system/hadoop.service` file with the following content: 
+Create the `/etc/systemd/system/hadoop.service` file with the following content:
 
 ```
 [Unit]
@@ -339,7 +339,7 @@ WantedBy=multi-user.target
 
 
 
-#### Start the service 
+#### Start the service
 
 ```bash
 service hadoop start
@@ -383,7 +383,7 @@ sudo apt-get install thehive4
 
 ### Configuration
 
-Following configurations are required to start TheHive successfully: 
+Following configurations are required to start TheHive successfully:
 
 - Secret key configuration
 - Database configuration
@@ -395,7 +395,7 @@ The secret key is automatically generated and stored in `/etc/thehive/secret.con
 
 #### Database
 
-To use Cassandra database, TheHive configuration file (`/etc/thehive/conf/application.conf`) has to be edited and updated with following lines:
+To use Cassandra database, TheHive configuration file (`/etc/thehive/application.conf`) has to be edited and updated with following lines:
 
 ```yaml
 db {
@@ -433,18 +433,18 @@ If you chose [Option 1: Local filesystem](#option:1_local_filesystem) to store f
 chown -R thehive:thehive /opt/thp_data/files/thehive
 ```
 
-- add following lines to TheHive configuration file (`/etc/thehive/conf/application.conf`)
+- add following lines to TheHive configuration file (`/etc/thehive/application.conf`)
 
 ```yml
 storage {
   provider = localfs
-  localfs.directory = /opt/files/thehive
+  localfs.directory = /opt/thp_data/files/thehive
 }
 ```
 
 #### Hadoop
 
-If you chose [Option 2: Hadoop](#option:2_hadoop) to store files in a distrubuted filesystem, add following lines to TheHive configuration file (`/etc/thehive/conf/application.conf`)
+If you chose [Option 2: Hadoop](#option:2_hadoop) to store files in a distrubuted filesystem, add following lines to TheHive configuration file (`/etc/thehive/application.conf`)
 
 ```yaml
 storage {

--- a/TheHive4/Installation/Install_rpm.md
+++ b/TheHive4/Installation/Install_rpm.md
@@ -68,19 +68,19 @@ By default, data is stored in `/var/lib/cassandra`.
 
 ### Configuration
 
-Start by changing the `cluster_name` with `thp`. Run the command `sqlsh`: 
+Start by changing the `cluster_name` with `thp`. Run the command `sqlsh`:
 
 ```bash
 UPDATE system.local SET cluster_name = 'thp' where key='local';
 ```
 
-Then run: 
+Then run:
 
 ```
 nodetool flush
 ```
 
-Configure Cassandra by editing `/etc/cassandra/conf/cassandra.yaml` file. 
+Configure Cassandra by editing `/etc/cassandra/conf/cassandra.yaml` file.
 
 
 ```yml
@@ -117,7 +117,7 @@ By default Cassandra listens on `7000/tcp` (inter-node), `9042/tcp` (client).
 
 ⚠️ **Note**
 
-Cassandra service does not start well with the new systemd version. There is an existing issue and a fix on Apache website: https://issues.apache.org/jira/browse/CASSANDRA-15273 
+Cassandra service does not start well with the new systemd version. There is an existing issue and a fix on Apache website: https://issues.apache.org/jira/browse/CASSANDRA-15273
 
 ---
 
@@ -139,13 +139,13 @@ To add Cassandra nodes, refer the the [related administration guide](../Administ
 
 ## Choose and install attachment storage
 
-Files uploaded in TheHive (in *task logs* or in *observables*) can be stores in localsystem, in a Hadoop filesystem (recommended) or in the graph database. 
+Files uploaded in TheHive (in *task logs* or in *observables*) can be stores in localsystem, in a Hadoop filesystem (recommended) or in the graph database.
 
 For standalone production and test servers , we recommends using local filesystem. If you think about building a cluster with TheHive, use Hadoop filesystem.
 
 ### Option 1: Local filesystem
 
-**Note**: This option is perfect if you **do not** intend to build a cluster for your instance of TheHive 4. 
+**Note**: This option is perfect if you **do not** intend to build a cluster for your instance of TheHive 4.
 
 To store files on the local filesystem, start by choosing the dedicated folder:
 
@@ -153,11 +153,11 @@ To store files on the local filesystem, start by choosing the dedicated folder:
 mkdir -p /opt/thp_data/files/thehive
 ```
 
-This path will be used in the configuration of TheHive. 
+This path will be used in the configuration of TheHive.
 
 Later, after having installed TheHive, ensure the user `thehive` owns the path chosen for storing files:
 
-``` 
+```
 chown -R thehive:thehive /opt/thp_data/files/thehive
 ```
 
@@ -165,7 +165,7 @@ chown -R thehive:thehive /opt/thp_data/files/thehive
 
 If you choose Hadoop distributed filesystem, proceed to installation of the software before configuring it.
 
-#### Installation 
+#### Installation
 
 - Download hadoop distribution from https://hadoop.apache.org/releases.html and uncompress.
 
@@ -191,7 +191,7 @@ mkdir /opt/thp_data/hdfs
 chown hadoop:root -R /opt/thp_data/hdfs
 ```
 
-- Create ssh keys for `hadoop` user: 
+- Create ssh keys for `hadoop` user:
 
 ```bash
 su - hadoop
@@ -200,7 +200,7 @@ cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 chmod 0600 ~/.ssh/authorized_keys
 ```
 
-- Update `.bashrc`file for `hadoop user  in `/etc/environment`. Add following lines: 
+- Update `.bashrc`file for `hadoop user  in `/etc/environment`. Add following lines:
 
 ```
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
@@ -214,14 +214,14 @@ export YARN_HOME=$HADOOP_HOME
 ```
 
 
-**Note**: Apache has a well detailed [documentation](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SingleCluster.html) for more advanced configuration with Hadoop. 
+**Note**: Apache has a well detailed [documentation](https://hadoop.apache.org/docs/stable/hadoop-project-dist/hadoop-common/SingleCluster.html) for more advanced configuration with Hadoop.
 
 
 #### Configuration the Hadoop Master
 
-Configuration files are located in `etc/hadoop` (`/opt/hadoop/etc/hadoop`). They must be identical in all nodes. 
+Configuration files are located in `etc/hadoop` (`/opt/hadoop/etc/hadoop`). They must be identical in all nodes.
 
-**Notes**: 
+**Notes**:
 
 - The configuration described there is for a single node server. This node is the master node, namenode and datanode (refer to [Hadoop documentation](https://hadoop.apache.org/docs/current/) for more information). After validating this node is running successfully, refer to the [related administration guide](../Administration/Clustering.md) to add nodes;
 - Ensure you **update** the port value to something different than `9000` as it is already reserved for TheHive application service;
@@ -301,7 +301,7 @@ bin/hdfs namenode -format
 
 ---
 
-Create the `/etc/systemd/system/hadoop.service` file with the following content: 
+Create the `/etc/systemd/system/hadoop.service` file with the following content:
 
 ```
 [Unit]
@@ -351,7 +351,7 @@ WantedBy=multi-user.target
 
 
 
-#### Start the service 
+#### Start the service
 
 ```bash
 service hadoop start
@@ -390,7 +390,7 @@ Run the following command to import the GPG key :
 sudo rpm --import https://raw.githubusercontent.com/TheHive-Project/TheHive/master/PGP-PUBLIC-KEY
 ```
 
-And setup your system to connect the RPM repository. Create and edit the file `/etc/yum.repos.d/thehive-project.repo`: 
+And setup your system to connect the RPM repository. Create and edit the file `/etc/yum.repos.d/thehive-project.repo`:
 
 ```bash
 [thehive-project]
@@ -408,7 +408,7 @@ yum install thehive4
 
 ### Configuration
 
-Following configurations are required to start TheHive successfully: 
+Following configurations are required to start TheHive successfully:
 
 - Secret key configuration
 - Database configuration
@@ -420,7 +420,7 @@ The secret key is automatically generated and stored in `/etc/thehive/secret.con
 
 #### Database
 
-To use Cassandra database, TheHive configuration file (`/etc/thehive/conf/application.conf`) has to be edited and updated with following lines:
+To use Cassandra database, TheHive configuration file (`/etc/thehive/application.conf`) has to be edited and updated with following lines:
 
 ```yaml
 db {
@@ -458,18 +458,18 @@ If you chose [Option 1: Local filesystem](#option:1_local_filesystem) to store f
 chown -R thehive:thehive /opt/thp_data/files/thehive
 ```
 
-- add following lines to TheHive configuration file (`/etc/thehive/conf/application.conf`)
+- add following lines to TheHive configuration file (`/etc/thehive/application.conf`)
 
 ```yml
 storage {
   provider = localfs
-  localfs.directory = /opt/files/thehive
+  localfs.directory = /opt/thp_data/files/thehive
 }
 ```
 
 #### Hadoop
 
-If you chose [Option 2: Hadoop](#option:2_hadoop) to store files in a distrubuted filesystem, add following lines to TheHive configuration file (`/etc/thehive/conf/application.conf`)
+If you chose [Option 2: Hadoop](#option:2_hadoop) to store files in a distrubuted filesystem, add following lines to TheHive configuration file (`/etc/thehive/application.conf`)
 
 ```yaml
 storage {


### PR DESCRIPTION
Fix inconsistencies between ./conf/application.conf and real usage of ./application.conf 
Same with /opt/thp_data/files/ instead of /opt/files/

Maybe I missed something but ./conf/application.conf is not used by ./application.conf

Thx for the great work !