### PR TITLE
Update install_rpm.md | Fix path

### DIFF
--- a/TheHive4/Installation/Install_rpm.md
+++ b/TheHive4/Installation/Install_rpm.md
@@ -474,7 +474,7 @@ chown -R thehive:thehive /opt/thp_data/files/thehive
 ```yml
 storage {
 provider = localfs
-localfs.location = /opt/files/thehive
+localfs.location = /opt/thp_data/files/thehive
 }
 ```
 


### PR DESCRIPTION
Fixing path in config example.
Without this change, example not work.
Checked on CentOS Linux release 7.7.1908 (Core)