### PR TITLE
Missing Content-Type in doc

### DIFF
--- a/admin/backup-restore.md
+++ b/admin/backup-restore.md
@@ -107,7 +107,7 @@ You can backup the last index of TheHive (you can list indices in your Elasticse
 Restore will do the reverse actions : it reads the backup in your snapshot directory and loads indices into the Elasticsearch
 cluster. This operation is done with the following command :
 ```
-$ curl -XPOST 'http://localhost:9200/_snapshot/the_hive_backup/snapshot_1/_restore' -d '
+$ curl -XPOST 'http://localhost:9200/_snapshot/the_hive_backup/snapshot_1/_restore' -H 'Content-Type: application/json' -d '
 {
   "indices": "<INDEX>"
 }'

--- a/admin/upgrade_to_thehive_3_4_and_es_6_x.md
+++ b/admin/upgrade_to_thehive_3_4_and_es_6_x.md
@@ -5,7 +5,7 @@ This document is related to upgrading TheHive and Elasticsearch on **Ubuntu 16.0
 #### Perform a backup of data
 
 ```bash
-curl -XPUT 'http://localhost:9200/_snapshot/the_hive_backup' -d '{
+curl -XPUT 'http://localhost:9200/_snapshot/the_hive_backup' -H 'Content-Type: application/json' -d '{
     "type": "fs",
     "settings": {
         "location": "/absolute/path/to/backup/directory",
@@ -17,7 +17,7 @@ curl -XPUT 'http://localhost:9200/_snapshot/the_hive_backup' -d '{
 For example: 
 
 ```bash
-curl -XPUT 'http://localhost:9200/_snapshot/the_hive_backup' -d '{
+curl -XPUT 'http://localhost:9200/_snapshot/the_hive_backup' -H 'Content-Type: application/json' -d '{
     "type": "fs",
     "settings": {
         "location": "/opt/backup",
@@ -29,7 +29,7 @@ curl -XPUT 'http://localhost:9200/_snapshot/the_hive_backup' -d '{
 Next:
 
 ```bash
-curl -XPUT 'http://localhost:9200/_snapshot/the_hive_backup/snapshot_1?wait_for_completion=true&pretty' -d '{
+curl -XPUT 'http://localhost:9200/_snapshot/the_hive_backup/snapshot_1?wait_for_completion=true&pretty' -H 'Content-Type: application/json' -d '{
   "indices": "<INDEX>"
 }'
 ```
@@ -37,7 +37,7 @@ curl -XPUT 'http://localhost:9200/_snapshot/the_hive_backup/snapshot_1?wait_for_
 For example:
 
 ```bash
-curl -XPUT 'http://localhost:9200/_snapshot/the_hive_backup/the_hive_152019060701_1?wait_for_completion=true&pretty' -d '{
+curl -XPUT 'http://localhost:9200/_snapshot/the_hive_backup/the_hive_152019060701_1?wait_for_completion=true&pretty' -H 'Content-Type: application/json' -d '{
   "indices": "the_hive_15"
 }'
 ```


### PR DESCRIPTION
Hello,

by following the doc I stumbled on those `curl` commands that will yield an `{"error":"Content-Type header [application/x-www-form-urlencoded] is not supported","status":406}` because of the missing proper `Content-Type` header.

Here is a PR that should fill the gap.
Cheers,

-- 
Mathieu
