### PR TITLE
Update Install_deb.md

### DIFF
--- a/TheHive4/Installation/Install_deb.md
+++ b/TheHive4/Installation/Install_deb.md
@@ -176,7 +176,7 @@ ln -s hadoop-3.1.3 hadoop
 - Create a user and update permissions
 
 ```bash
-useradd hadoop
+useradd -m hadoop
 chown hadoop:root -R /opt/hadoop*
 ```
 


### PR DESCRIPTION
the user hadoop needs a home directory in order to store the ssh key and needs to created via "useradd -m hadoop"